### PR TITLE
Fix boxed math warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: clojure
+dist: trusty
 script: lein do clean, test
 sudo: false
 jdk:

--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -116,7 +116,7 @@
     (potemkin.collections/compile-if (resolve 'clojure.core/hash-unordered-coll)
       (hash-unordered-coll (or (seq this) ()))
       (reduce
-        (fn [acc [k v]]
+        (fn [^long acc [k v]]
           (unchecked-add acc (bit-xor (hash k) (hash v))))
         0
         (seq this))))
@@ -124,7 +124,7 @@
   Object
   (hashCode [this]
     (reduce
-      (fn [acc [k v]]
+      (fn [^long acc [k v]]
         (unchecked-add acc (bit-xor (clojure.lang.Util/hash k)
                                     (clojure.lang.Util/hash v))))
       0


### PR DESCRIPTION
Type hinting the accumulator as `^long` fixes the boxed math warning. If there is an issue with using `long` please advise.

Fixes #60