### PR TITLE
Resolve imported vars at runtime, not read time

### DIFF
--- a/src/potemkin/namespaces.clj
+++ b/src/potemkin/namespaces.clj
@@ -26,11 +26,11 @@
          (throw (IllegalArgumentException.
                   (str "Calling import-fn on a macro: " sym))))
 
-       `(do
-          (def ~(with-meta n {:protocol protocol}) (deref ~vr))
-          (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
-          (link-vars ~vr (var ~n))
-          ~vr))))
+       `(let [vr# (resolve '~sym)]
+          (def ~(with-meta n {:protocol protocol}) (deref vr#))
+          (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
+          (link-vars vr# (var ~n))
+          vr#))))
 
 (defmacro import-macro
   "Given a macro in another namespace, defines a macro with the same
@@ -48,12 +48,12 @@
        (when-not (:macro m)
          (throw (IllegalArgumentException.
                   (str "Calling import-macro on a non-macro: " sym))))
-       `(do
-          (def ~n ~(resolve sym))
-          (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
+       `(let [vr# (resolve '~sym)]
+          (def ~n (deref vr#))
+          (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
           (.setMacro (var ~n))
-          (link-vars ~vr (var ~n))
-          ~vr))))
+          (link-vars vr# (var ~n))
+          vr#))))
 
 (defmacro import-def
   "Given a regular def'd var from another namespace, defined a new var with the
@@ -68,11 +68,11 @@
            nspace (:ns m)]
        (when-not vr
          (throw (IllegalArgumentException. (str "Don't recognize " sym))))
-       `(do
-          (def ~n @~vr)
-          (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
-          (link-vars ~vr (var ~n))
-          ~vr))))
+       `(let [vr# (resolve '~sym)]
+          (def ~n (deref vr#))
+          (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
+          (link-vars vr# (var ~n))
+          vr#))))
 
 (defmacro import-vars
   "Imports a list of vars from other namespaces."

--- a/test/potemkin/imports_test.clj
+++ b/test/potemkin/imports_test.clj
@@ -20,3 +20,6 @@
   x)
 
 (def some-value 1)
+
+(defn ^clojure.lang.ExceptionInfo ex-info-2 [msg data]
+  (ex-info msg data))

--- a/test/potemkin/namespaces_test.clj
+++ b/test/potemkin/namespaces_test.clj
@@ -50,3 +50,6 @@
     (is false "`import-vars` should have thrown an exception")
   (catch Exception ex
     (is "`clojure.set/onion-misspelled` does not exist" (.getMessage ex)))))
+
+;; This is the whole test for CLJ-1929
+(import-vars [potemkin.imports-test ex-info-2])


### PR DESCRIPTION
If a var has tag metadata attached to the var symbol (not on the vector, as is the preferred method for return types in functions), it will be resolved when `import-*` is called during read time. This currently doesn't break anything, but if the proposed Clojure patch for [CLJ-1929][CLJ-1929] is accepted, then code that's so tagged will break.

Includes a test that will break without the associated change if the Clojure patch is accepted.

Closes #72

[CLJ-1929]: https://clojure.atlassian.net/browse/CLJ-1929