### PR TITLE
Remove dependency on clj-tuple

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,7 @@
   :deploy-repositories [["clojars" {:url "https://repo.clojars.org"
                                     :sign-releases false}]]
 
-  :dependencies [[clj-tuple "0.2.2"]
-                 [riddley "0.1.12"]]
+  :dependencies [[riddley "0.1.12"]]
   :profiles {:dev {:dependencies [[criterium "0.4.6"]
                                   [collection-check "0.1.6"]]}
              :provided {:dependencies [[org.clojure/clojure "1.11.1"]]}}

--- a/src/potemkin/utils.clj
+++ b/src/potemkin/utils.clj
@@ -1,7 +1,6 @@
 (ns potemkin.utils
   (:require
-    [potemkin.macros :refer [unify-gensyms]]
-    [clj-tuple :as t])
+    [potemkin.macros :refer [unify-gensyms]])
   (:import
     [java.util.concurrent
      ConcurrentHashMap]))
@@ -101,7 +100,7 @@
      (if (nil? x#) ::nil x#)))
 
 (defmacro ^:no-doc memoize-form [m f & args]
-  `(let [k# (t/vector ~@args)]
+  `(let [k# [~@args]]
      (let [v# (.get ~m k#)]
        (if-not (nil? v#)
          (re-nil v#)


### PR DESCRIPTION
Currently, clj-tuple is used only by `potemkin.utils/fast-memoize`. I propose to remove it to slightly optimize the dependency graph of this library's consumers. Reasons:

1. It is used by a single function that is deprecated.
2. clj-tuple is an archived abandoned project.
3. clj-tuple doesn't improve the memory footprint that much over plain vectors (36 bytes per tuple). Here are the average size numbers of clj-tuple vs PersistentVector measured over 1,000,000 elements:

| Tuple elements | clj-tuple size in bytes | PV size in bytes |
|------------|-----------|----|
| 0          | 4         | 4  |
| 1          | 36        | 68 |
| 2          | 36        | 68 |
| 3          | 44        | 76 |
| 4          | 44        | 76 |
| 5          | 52        | 84 |
| 6          | 52        | 84 |