### PR TITLE
Support renaming with `:as` in import-vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The former approach places an onus on the creator of the library; the various or
 ```clojure
 (import-vars
   [clojure.walk
-    prewalk
+    [prewalk :as walk-pre]
     postwalk]
   [clojure.data
     diff])

--- a/test/potemkin/namespaces_test.clj
+++ b/test/potemkin/namespaces_test.clj
@@ -13,6 +13,10 @@
 (import-fn i/protocol-function)
 (import-fn i/inlined-fn)
 (import-def i/some-value)
+(import-vars [potemkin.imports-test
+              [multi-arity-macro :as renamed-multi-arity-macro]
+              [multi-arity-fn :as renamed-multi-arity-fn]
+              [some-value :as renamed-some-value]])
 
 
 (defn drop-lines [n s]
@@ -50,3 +54,10 @@
     (is false "`import-vars` should have thrown an exception")
   (catch Exception ex
     (is "`clojure.set/onion-misspelled` does not exist" (.getMessage ex)))))
+
+(deftest import-vars-allows-renaming
+  (is (= 1 renamed-some-value))
+  (is (out= (source i/multi-arity-fn) (source renamed-multi-arity-fn)))
+  (is (rest-out= (doc i/multi-arity-fn) (doc renamed-multi-arity-fn)))
+  (is (out= (source i/multi-arity-macro) (source renamed-multi-arity-macro)))
+  (is (rest-out= (doc i/multi-arity-macro) (doc renamed-multi-arity-macro))))


### PR DESCRIPTION
Add support for renaming symbols when using `import-vars`:

```clj
(import-vars
  [clojure.walk
    [prewalk :as walk-pre]
    postwalk]
  [clojure.data
    diff])
```

This is another attempt at making progress on the now 8 year old #47. #9 added this feature to `import-fn`, `import-macro`, and `import-def`, but not to `import-vars` (i.e. #46, which states that this was implemented also for `import-vars`, was a bit too optimistic in their reading of #9).

I've decided to keep the syntax more aligned with `require` and left the syntax+implementation open to support other keywords in the future if ever needed.

Since clj-kondo [special-cases `import-vars`](https://github.com/clj-kondo/clj-kondo/blob/ac7e4a28329b6c4b8407442054c1a886762128b8/src/clj_kondo/impl/analyzer/potemkin.clj), an additional PR will need to be made there - I will do this once this is merged. Importantly, this change does not break any backwards compatibility, and the PR to clj-kondo can be implemented in such a way that it is still compatible with older versions of potemkin too, so these changes don't need to be strictly synchronized.

---

Renaming symbols in `import-vars` is probably some form of anti-pattern. Nevertheless I've found it useful to build slightly modified versions of third-party libraries by redefining some of their public exports, and re-exporting the original symbols under a different name as an "escape hatch".