### PR TITLE
feat: support require like `import-vars`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ The former approach places an onus on the creator of the library; the various or
     diff])
 ```
 
+`import-vars` supports the `require` syntax of Clojure:
+
+```clojure
+(import-vars
+  [clojure.walk :refer [prewalk postwalk]])
+```
+
+Renaming is also supported with the `require` syntax:
+
+```clojure
+(import-vars
+  [clojure.walk :refer [prewalk postwalk] :rename {prewalk pre-walk}])
+```
+
 ### `def-map-type`
 
 A Clojure map implements the following interfaces: `clojure.lang.IPersistentCollection`, `clojure.lang.IPersistentMap`, `clojure.lang.Counted`, `clojure.lang.Seqable`, `clojure.lang.ILookup`, `clojure.lang.Associative`, `clojure.lang.IObj`, `java.lang.Object`, `java.util.Map`, `java.util.concurrent.Callable`, `java.lang.Runnable`, and `clojure.lang.IFn`.  Between them, there's a few dozen functions, many with overlapping functionality, all of which need to be correctly implemented.

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ This abstract type may be used within the body of `deftype+`, which is just like
 A drop in replacement for `defprotocol` that is more REPL-friendly.
 
 A protocol created with Clojure's `defprotocol` always creates new instance at load time.
-If a protocol is reloaded, a `defrecord` in another namespace that is referencing the procotol will not automatically be updated to the new protocol instance.
+If a protocol is reloaded, a `defrecord` in another namespace that is referencing the protocol will not automatically be updated to the new protocol instance.
 
 One telltale symptom of this disconnect can be a `No implementation of method` exception when calling record methods.
 
-Potemkin's `defprotocol+` improves the REPL experience by only creating a new instance of a protocol if the procotol body has changed.
+Potemkin's `defprotocol+` improves the REPL experience by only creating a new instance of a protocol if the protocol body has changed.
 
 ### `definterface+`
 

--- a/src/potemkin/namespaces.clj
+++ b/src/potemkin/namespaces.clj
@@ -4,100 +4,113 @@
   "Makes sure that all changes to `src` are reflected in `dst`."
   [src dst]
   (add-watch src dst
-    (fn [_ src old new]
-      (alter-var-root dst (constantly @src))
-      (alter-meta! dst merge (dissoc (meta src) :name)))))
+             (fn [_ src old new]
+               (alter-var-root dst (constantly @src))
+               (alter-meta! dst merge (dissoc (meta src) :name)))))
 
 (defmacro import-fn
   "Given a function in another namespace, defines a function with the
    same name in the current namespace.  Argument lists, doc-strings,
    and original line-numbers are preserved."
   ([sym]
-     `(import-fn ~sym nil))
+   `(import-fn ~sym nil))
   ([sym name]
-     (let [vr (resolve sym)
-           m (meta vr)
-           n (or name (:name m))
-           arglists (:arglists m)
-           protocol (:protocol m)]
-       (when-not vr
-         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
-       (when (:macro m)
-         (throw (IllegalArgumentException.
-                  (str "Calling import-fn on a macro: " sym))))
+   (let [vr (resolve sym)
+         m (meta vr)
+         n (or name (:name m))
+         arglists (:arglists m)
+         protocol (:protocol m)]
+     (when-not vr
+       (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+     (when (:macro m)
+       (throw (IllegalArgumentException.
+               (str "Calling import-fn on a macro: " sym))))
 
-       `(let [vr# (resolve '~sym)]
-          (def ~(with-meta n {:protocol protocol}) (deref vr#))
-          (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
-          (link-vars vr# (var ~n))
-          vr#))))
+     `(let [vr# (resolve '~sym)]
+        (def ~(with-meta n {:protocol protocol}) (deref vr#))
+        (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
+        (link-vars vr# (var ~n))
+        vr#))))
 
 (defmacro import-macro
   "Given a macro in another namespace, defines a macro with the same
    name in the current namespace.  Argument lists, doc-strings, and
    original line-numbers are preserved."
   ([sym]
-     `(import-macro ~sym nil))
+   `(import-macro ~sym nil))
   ([sym name]
-     (let [vr (resolve sym)
-           m (meta vr)
-           n (or name (with-meta (:name m) {}))
-           arglists (:arglists m)]
-       (when-not vr
-         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
-       (when-not (:macro m)
-         (throw (IllegalArgumentException.
-                  (str "Calling import-macro on a non-macro: " sym))))
-       `(let [vr# (resolve '~sym)]
-          (def ~n (deref vr#))
-          (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
-          (.setMacro (var ~n))
-          (link-vars vr# (var ~n))
-          vr#))))
+   (let [vr (resolve sym)
+         m (meta vr)
+         n (or name (with-meta (:name m) {}))
+         arglists (:arglists m)]
+     (when-not vr
+       (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+     (when-not (:macro m)
+       (throw (IllegalArgumentException.
+               (str "Calling import-macro on a non-macro: " sym))))
+     `(let [vr# (resolve '~sym)]
+        (def ~n (deref vr#))
+        (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
+        (.setMacro (var ~n))
+        (link-vars vr# (var ~n))
+        vr#))))
 
 (defmacro import-def
   "Given a regular def'd var from another namespace, defined a new var with the
    same name in the current namespace."
   ([sym]
-     `(import-def ~sym nil))
+   `(import-def ~sym nil))
   ([sym name]
-     (let [vr (resolve sym)
-           m (meta vr)
-           n (or name (:name m))
-           n (with-meta n (if (:dynamic m) {:dynamic true} {}))
-           nspace (:ns m)]
-       (when-not vr
-         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
-       `(let [vr# (resolve '~sym)]
-          (def ~n (deref vr#))
-          (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
-          (link-vars vr# (var ~n))
-          vr#))))
+   (let [vr (resolve sym)
+         m (meta vr)
+         n (or name (:name m))
+         n (with-meta n (if (:dynamic m) {:dynamic true} {}))
+         nspace (:ns m)]
+     (when-not vr
+       (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+     `(let [vr# (resolve '~sym)]
+        (def ~n (deref vr#))
+        (alter-meta! (var ~n) merge (dissoc (meta vr#) :name))
+        (link-vars vr# (var ~n))
+        vr#))))
+
+(defn- unravel* [x]
+  (if (sequential? x)
+    (->> x
+         rest
+         (mapcat unravel*)
+         (map
+          #(symbol
+            (str (first x)
+                 (when-let [n (namespace %)]
+                   (str "." n)))
+            (name %))))
+    [x]))
+
+(defn- unravel [x]
+  (or (and (sequential? x)
+           (let [[ns refer-kw refers rename-kw renames] x]
+             (when (and (= :refer refer-kw)
+                        (sequential? refers)
+                        (or (and (nil? rename-kw) (nil? renames))
+                            (and (= :rename rename-kw) (map? renames))))
+               (map #(with-meta (symbol (str ns) (name %)) {:name (get renames %)})
+                    refers))))
+      (unravel* x)))
 
 (defmacro import-vars
   "Imports a list of vars from other namespaces."
   [& syms]
-  (let [unravel (fn unravel [x]
-                  (if (sequential? x)
-                    (->> x
-                         rest
-                         (mapcat unravel)
-                         (map
-                          #(symbol
-                            (str (first x)
-                                 (when-let [n (namespace %)]
-                                   (str "." n)))
-                            (name %))))
-                    [x]))
-        syms (mapcat unravel syms)]
+  (let [syms (mapcat unravel syms)]
     `(do
        ~@(map
           (fn [sym]
             (let [vr (resolve sym)
-                  m (meta vr)]
+                  m (meta vr)
+                  ?name (-> sym meta :name)]
               (cond
-               (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
-               (:macro m) `(import-macro ~sym)
-               (:arglists m) `(import-fn ~sym)
-               :else `(import-def ~sym))))
+                (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
+                (:macro m) `(import-macro ~sym ~?name)
+                (:arglists m) `(import-fn ~sym ~?name)
+                :else `(import-def ~sym ~?name))))
           syms))))

--- a/test/potemkin/imports_test.clj
+++ b/test/potemkin/imports_test.clj
@@ -23,3 +23,7 @@
 
 (defn ^clojure.lang.ExceptionInfo ex-info-2 [msg data]
   (ex-info msg data))
+
+(def some-other-value 2)
+
+(defn some-other-fn [] 1)

--- a/test/potemkin/namespaces_test.clj
+++ b/test/potemkin/namespaces_test.clj
@@ -1,10 +1,10 @@
 (ns potemkin.namespaces-test
   (:require
-    [clojure.repl :as repl :refer :all]
-    [clojure.string :as str]
-    [clojure.test :refer :all]
-    [potemkin :refer :all]
-    [potemkin.imports-test :as i]))
+   [clojure.repl :as repl :refer :all]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [potemkin :refer :all]
+   [potemkin.imports-test :as i]))
 
 (import-macro i/multi-arity-macro)
 (import-macro i/multi-arity-macro alt-macro-name)
@@ -13,7 +13,12 @@
 (import-fn i/protocol-function)
 (import-fn i/inlined-fn)
 (import-def i/some-value)
-
+(import-vars [i :refer [some-other-fn]])
+(import-vars [i
+              :refer [multi-arity-macro multi-arity-fn some-value some-other-value]
+              :rename {multi-arity-macro renamed-multi-arity-macro
+                       multi-arity-fn renamed-multi-arity-fn
+                       some-value renamed-some-value}])
 
 (defn drop-lines [n s]
   (->> s str/split-lines (drop n) (interpose "\n") (apply str)))
@@ -48,8 +53,19 @@
   (try
     (import-vars [clojure.set union onion-misspelled])
     (is false "`import-vars` should have thrown an exception")
-  (catch Exception ex
-    (is "`clojure.set/onion-misspelled` does not exist" (.getMessage ex)))))
+    (catch Exception ex
+      (is "`clojure.set/onion-misspelled` does not exist" (.getMessage ex)))))
+
+(deftest import-vars-supports-refers
+  (is (fn? some-other-fn)))
+
+(deftest import-vars-allows-renaming
+  (is (= 1 renamed-some-value))
+  (is (= 2 some-other-value))
+  (is (out= (source i/multi-arity-fn) (source renamed-multi-arity-fn)))
+  (is (rest-out= (doc i/multi-arity-fn) (doc renamed-multi-arity-fn)))
+  (is (out= (source i/multi-arity-macro) (source renamed-multi-arity-macro)))
+  (is (rest-out= (doc i/multi-arity-macro) (doc renamed-multi-arity-macro))))
 
 ;; This is the whole test for CLJ-1929
 (import-vars [potemkin.imports-test ex-info-2])


### PR DESCRIPTION
With this feature we add support for renaming the imported vars similar to the Clojure's `require` syntax.

Relates to #9
Closes #47
Closes #77
Fixes #46