### PR TITLE
Fix namespaced symbols in syntax quoted binding vector

### DIFF
--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -298,9 +298,9 @@
                  (fn [[name f]]
                    (list name `[_#] f))))
 
-           (~'meta [_] meta##)
+           (~'meta [~'_] meta##)
 
-           (~'with-meta [_ x#]
+           (~'with-meta [~'_ x#]
              (new ~name ~@params key-set## added## x#))
 
            (~'get [this## key# default-value#]


### PR DESCRIPTION
These underscores in a syntax quoted form cause the macroexpansion to contain the following technically invalid binding forms (even if `deftype` accepts it without complaining)
```clj
(deftype ...
  (meta [potemkin.collections/_] ...)
  (with-meta [potemkin.collections/_ x__1234__auto__] ...)
  ...)
```