### PR TITLE
Remove defprotocol+, fix reloading deftype+ behavior

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject potemkin "0.4.8"
+(defproject griffinbank/potemkin "0.4.9-20250811"
   :license {:name "MIT License"}
   :description "Some useful facades."
   :deploy-repositories [["clojars" {:url "https://repo.clojars.org"


### PR DESCRIPTION
Remove `defprotocol+`. Remove the "don't redefine if the class hasn't changed" behavior from deftype+. Both of these cause problems for rules_clojure, and are generally just a code smell.